### PR TITLE
Add maven half support

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk9.json
+++ b/org.freedesktop.Sdk.Extension.openjdk9.json
@@ -210,6 +210,7 @@
               "mkdir -p $FLATPAK_DEST/share/maven",
               "mkdir -p $FLATPAK_DEST/etc/maven",
               "cp -a * $FLATPAK_DEST/share/maven/",
+              "rm -rf $FLATPAK_DEST/share/maven/lib/jansi-native",
               "ln -sf $FLATPAK_DEST/share/maven/bin/mvn $FLATPAK_DEST/bin/mvn",
               "ln -sf $FLATPAK_DEST/share/maven/bin/mvnDebug $FLATPAK_DEST/bin/mvnDebug",
               "ln -sf $FLATPAK_DEST/share/maven/bin/mvnyjp $FLATPAK_DEST/bin/mvnyjp",

--- a/org.freedesktop.Sdk.Extension.openjdk9.json
+++ b/org.freedesktop.Sdk.Extension.openjdk9.json
@@ -202,6 +202,36 @@
                     "path": "org.freedesktop.Sdk.Extension.openjdk9.appdata.xml"
                 }
             ]
+        },
+        {
+            "name": "maven",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install-maven.sh"
+            ],
+            "sources": [
+                {
+                    "type": "script",
+                    "commands": [
+                        "mkdir -p /app/share/maven",
+                        "mkdir -p /app/etc/maven",
+                        "tar xvf maven.tar.gz -C /app/share/maven --strip-components=1",
+                        "ln -sf /app/share/maven/bin/mvn /app/bin/mvn",
+                        "ln -sf /app/share/maven/bin/mvnDebug /app/bin/mvnDebug",
+                        "ln -sf /app/share/maven/bin/mvnyjp /app/bin/mvnyjp",
+                        "ln -sf /app/share/maven/conf/logging /app/etc/maven/logging",
+                        "ln -sf /app/share/maven/conf/settings.xml /app/etc/maven/setting.xml"
+                    ],
+                    "dest-filename": "install-maven.sh"
+                },
+                {
+                    "type": "extra-data",
+                    "filename": "maven.tar.gz",
+                    "url": "http://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz",
+                    "sha256": "707b1f6e390a65bde4af4cdaf2a24d45fc19a6ded00fff02e91626e3e42ceaff",
+                    "size": 8738691
+                }
+            ]
         }
     ]
 }

--- a/org.freedesktop.Sdk.Extension.openjdk9.json
+++ b/org.freedesktop.Sdk.Extension.openjdk9.json
@@ -207,29 +207,20 @@
             "name": "maven",
             "buildsystem": "simple",
             "build-commands": [
-                "install-maven.sh"
+              "mkdir -p $FLATPAK_DEST/share/maven",
+              "mkdir -p $FLATPAK_DEST/etc/maven",
+              "cp -a * $FLATPAK_DEST/share/maven/",
+              "ln -sf $FLATPAK_DEST/share/maven/bin/mvn $FLATPAK_DEST/bin/mvn",
+              "ln -sf $FLATPAK_DEST/share/maven/bin/mvnDebug $FLATPAK_DEST/bin/mvnDebug",
+              "ln -sf $FLATPAK_DEST/share/maven/bin/mvnyjp $FLATPAK_DEST/bin/mvnyjp",
+              "ln -sf $FLATPAK_DEST/share/maven/conf/logging $FLATPAK_DEST/etc/maven/logging",
+              "ln -sf $FLATPAK_DEST/share/maven/conf/settings.xml $FLATPAK_DEST/etc/maven/setting.xml"
             ],
             "sources": [
                 {
-                    "type": "script",
-                    "commands": [
-                        "mkdir -p /app/share/maven",
-                        "mkdir -p /app/etc/maven",
-                        "tar xvf maven.tar.gz -C /app/share/maven --strip-components=1",
-                        "ln -sf /app/share/maven/bin/mvn /app/bin/mvn",
-                        "ln -sf /app/share/maven/bin/mvnDebug /app/bin/mvnDebug",
-                        "ln -sf /app/share/maven/bin/mvnyjp /app/bin/mvnyjp",
-                        "ln -sf /app/share/maven/conf/logging /app/etc/maven/logging",
-                        "ln -sf /app/share/maven/conf/settings.xml /app/etc/maven/setting.xml"
-                    ],
-                    "dest-filename": "install-maven.sh"
-                },
-                {
-                    "type": "extra-data",
-                    "filename": "maven.tar.gz",
+                    "type": "archive",
                     "url": "http://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz",
-                    "sha256": "707b1f6e390a65bde4af4cdaf2a24d45fc19a6ded00fff02e91626e3e42ceaff",
-                    "size": 8738691
+                    "sha256": "707b1f6e390a65bde4af4cdaf2a24d45fc19a6ded00fff02e91626e3e42ceaff"
                 }
             ]
         }


### PR DESCRIPTION
Added maven build system as extra data. Building maven at the moment is not possible as maven also downloads build dependencies on it own at build time. To build maven or applications based on it will probably need maven native support in flatpak-builder.