### PR TITLE
Add full jdk option

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk9.json
+++ b/org.freedesktop.Sdk.Extension.openjdk9.json
@@ -181,7 +181,7 @@
                     "commands": [
                         "mkdir -p /app/jdk/",
                         "cd /usr/lib/sdk/openjdk9/jvm/openjdk-9",
-                        "cp -ra lib conf bin /app/jre/",
+                        "cp -ra lib conf bin /app/jdk/",
                         "rm /app/jdk/lib/src.zip"
                     ],
                     "dest-filename": "installjdk.sh"

--- a/org.freedesktop.Sdk.Extension.openjdk9.json
+++ b/org.freedesktop.Sdk.Extension.openjdk9.json
@@ -179,6 +179,16 @@
                 {
                     "type": "script",
                     "commands": [
+                        "mkdir -p /app/jdk/",
+                        "cd /usr/lib/sdk/openjdk9/jvm/openjdk-9",
+                        "cp -ra lib conf bin /app/jre/",
+                        "rm /app/jdk/lib/src.zip"
+                    ],
+                    "dest-filename": "installjdk.sh"
+                },
+                {
+                    "type": "script",
+                    "commands": [
                         "export PATH=$PATH:/usr/lib/sdk/openjdk9/bin"
                     ],
                     "dest-filename": "enable.sh"
@@ -186,7 +196,7 @@
             ],
             "buildsystem": "simple",
             "build-commands": [
-                "cp enable.sh install.sh /usr/lib/sdk/openjdk9/"
+                "cp enable.sh install.sh installjdk.sh /usr/lib/sdk/openjdk9/"
             ]
         },
         {


### PR DESCRIPTION
Fix #3? One may need the full jdk with javac, keytool, jarsigner, etc. This extension is called openjdk, not jre, after all.